### PR TITLE
Refactor MCP tools with DB helper

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,0 +1,11 @@
+"""Run the ChefByte MCP tool server."""
+
+from mcp_tools import mcp  # FastMCP instance
+import mcp_tools.push_tools  # noqa: F401 - register tools
+import mcp_tools.pull_tools  # noqa: F401 - register tools
+import mcp_tools.action_tools  # noqa: F401 - register tools
+
+if __name__ == "__main__":
+    # Run an HTTP server on localhost for testing
+    mcp.run(transport="http", port=8000)
+

--- a/mcp_tools/__init__.py
+++ b/mcp_tools/__init__.py
@@ -1,0 +1,4 @@
+"""MCP tool server initialization."""
+from fastmcp import FastMCP
+
+mcp = FastMCP("ChefByte Tools")

--- a/mcp_tools/action_tools.py
+++ b/mcp_tools/action_tools.py
@@ -1,0 +1,79 @@
+"""High-level action tools that orchestrate complex tasks.
+
+These wrappers delegate to specialized engines such as the
+meal planner, suggestion generator and meal ideation engine.
+They maintain short-lived database connections and return the
+final text result produced by those engines.
+"""
+
+from . import mcp
+from langchain.schema import HumanMessage
+from db.db_functions import with_db
+from tools.meal_planner import MealPlanningTool
+from tools.meal_suggestion_gen import generate_meal_suggestions as original_generate_suggestions
+from tools.new_meal_ideation import MealIdeationEngine
+import traceback
+
+
+@mcp.tool
+@with_db
+def run_meal_planner(db, tables, user_request: str) -> str:
+    """Execute the multi-step meal planning workflow.
+
+    Args:
+        user_request: Instructions or questions about planning upcoming meals.
+
+    Returns:
+        The final plan text produced by the meal planner.
+    """
+    try:
+        planner = MealPlanningTool(db, tables)
+        minimal_history = [HumanMessage(content=user_request)]
+        return planner.execute(minimal_history)
+    except Exception as e:
+        print(f"[ERROR] in run_meal_planner: {e}")
+        traceback.print_exc()
+        return f"Sorry, an error occurred during meal planning: {e}"
+
+
+@mcp.tool
+def run_meal_suggestion_generator(user_request: str) -> str:
+    """Generate meal suggestions from user criteria.
+
+    Args:
+        user_request: A prompt describing desired meals or ingredient limits.
+
+    Returns:
+        A formatted string of meal suggestion text.
+    """
+    print(f"[Tool Wrapper] run_meal_suggestion_generator called with: {user_request[:100]}...")
+    try:
+        minimal_history = [HumanMessage(content=user_request)]
+        result = original_generate_suggestions(minimal_history)
+        return result
+    except Exception as e:
+        print(f"[ERROR] in run_meal_suggestion_generator: {e}")
+        traceback.print_exc()
+        return f"Sorry, an error occurred while generating meal suggestions: {e}"
+
+
+@mcp.tool
+@with_db
+def run_new_meal_ideator(db, tables, user_request: str) -> str:
+    """Generate creative new meal ideas or recipes.
+
+    Args:
+        user_request: Prompt describing desired concept or inspiration.
+
+    Returns:
+        The generated recipe or idea text.
+    """
+    print(f"[Tool Wrapper] run_new_meal_ideator called with: {user_request[:100]}...")
+    try:
+        engine = MealIdeationEngine(db, tables)
+        minimal_history = [HumanMessage(content=user_request)]
+        return engine.execute(minimal_history)
+    except Exception as e:
+        print(f"[ERROR] in run_new_meal_ideator: {e}")
+        traceback.print_exc()
+        return f"Sorry, an error occurred during meal ideation: {e}"

--- a/mcp_tools/pull_tools.py
+++ b/mcp_tools/pull_tools.py
@@ -1,0 +1,148 @@
+"""Tools for retrieving context information from the database.
+
+Each function opens a temporary connection, collects the
+requested data using the ``PullHelper`` utility class and
+returns a plain string summary for the agent to use.
+"""
+
+from . import mcp
+from db.db_functions import with_db
+from helpers.pull_helper import PullHelper
+import traceback
+
+
+@mcp.tool
+@with_db
+def get_inventory_context(db, tables) -> str:
+    """Retrieve a summary of the current kitchen inventory.
+
+    Returns:
+        A plain text listing of items and amounts on hand.
+    """
+    print("[Tool Called] get_inventory_context")
+    try:
+        pull_helper = PullHelper(db, tables)
+        return pull_helper.get_inventory_context()
+    except Exception as e:
+        print(f"[ERROR] Tool 'get_inventory_context' failed: {e}")
+        return f"Error during inventory retrieval: {str(e)}"
+
+
+@mcp.tool
+@with_db
+def get_taste_profile_context(db, tables) -> str:
+    """Get the saved taste profile.
+
+    Returns:
+        A description of likes, dislikes and dietary restrictions.
+    """
+    print("[Tool Called] get_taste_profile_context")
+    try:
+        pull_helper = PullHelper(db, tables)
+        return pull_helper.get_taste_profile_context()
+    except Exception as e:
+        print(f"[ERROR] Tool 'get_taste_profile_context' failed: {e}")
+        return f"Error retrieving taste profile: {str(e)}"
+
+
+@mcp.tool
+@with_db
+def get_saved_meals_context(db, tables) -> str:
+    """List stored meals and recipes.
+
+    Returns:
+        Text summary of all meals saved by the user.
+    """
+    print("[Tool Called] get_saved_meals_context")
+    try:
+        pull_helper = PullHelper(db, tables)
+        return pull_helper.get_saved_meals_context()
+    except Exception as e:
+        print(f"[ERROR] Tool 'get_saved_meals_context' failed: {e}")
+        return f"Error retrieving saved meals: {str(e)}"
+
+
+@mcp.tool
+@with_db
+def get_shopping_list_context(db, tables) -> str:
+    """Retrieve the current shopping list.
+
+    Returns:
+        Plain text list of ingredients and quantities to purchase.
+    """
+    print("[Tool Called] get_shopping_list_context")
+    try:
+        pull_helper = PullHelper(db, tables)
+        return pull_helper.get_shopping_list_context()
+    except Exception as e:
+        print(f"[ERROR] Tool 'get_shopping_list_context' failed: {e}")
+        return f"Error during shopping list retrieval: {str(e)}"
+
+
+@mcp.tool
+@with_db
+def get_daily_notes_context(db, tables) -> str:
+    """Get the meal plan for the upcoming week.
+
+    Returns:
+        A text summary of planned meals and notes for the next seven days.
+    """
+    print("[Tool Called] get_daily_notes_context")
+    try:
+        pull_helper = PullHelper(db, tables)
+        return pull_helper.get_daily_notes_context()
+    except Exception as e:
+        print(f"[ERROR] Tool 'get_daily_notes_context' failed: {e}")
+        print(traceback.format_exc())
+        return "Error retrieving daily meal plans."
+
+
+@mcp.tool
+@with_db
+def get_new_meal_ideas_context(db, tables) -> str:
+    """List previously generated meal ideas.
+
+    Returns:
+        A newline-separated list of stored suggestions.
+    """
+    print("[Tool Called] get_new_meal_ideas_context")
+    try:
+        pull_helper = PullHelper(db, tables)
+        return pull_helper.get_new_meal_ideas_context()
+    except Exception as e:
+        print(f"[ERROR] Tool 'get_new_meal_ideas_context' failed: {e}")
+        return f"Error retrieving new meal ideas: {str(e)}"
+
+
+@mcp.tool
+@with_db
+def get_instock_meals_context(db, tables) -> str:
+    """Find meals that can be prepared with current inventory.
+
+    Returns:
+        Text listing of saved and new meals possible with ingredients on hand.
+    """
+    print("[Tool Called] get_instock_meals_context")
+    try:
+        pull_helper = PullHelper(db, tables)
+        return pull_helper.get_instock_meals_context()
+    except Exception as e:
+        print(f"[ERROR] Tool 'get_instock_meals_context' failed: {e}")
+        return f"Error retrieving in-stock meals: {str(e)}"
+
+
+@mcp.tool
+@with_db
+def get_ingredients_info_context(db, tables) -> str:
+    """Provide general information about ingredients.
+
+    Returns:
+        Tips such as purchase amounts or reference links for ingredients.
+    """
+    print("[Tool Called] get_ingredients_info_context")
+    try:
+        pull_helper = PullHelper(db, tables)
+        return pull_helper.get_ingredients_info_context()
+    except Exception as e:
+        print(f"[ERROR] Tool 'get_ingredients_info_context' failed: {e}")
+        return f"Error retrieving ingredients information: {str(e)}"

--- a/mcp_tools/push_tools.py
+++ b/mcp_tools/push_tools.py
@@ -1,0 +1,131 @@
+"""Tools for updating database records.
+
+These functions process natural language requests to modify
+ChefByte's data tables. Each tool initializes a database
+connection, delegates parsing and update logic to helper
+classes, and returns a confirmation string describing the
+changes made.
+"""
+
+from . import mcp
+from db.db_functions import with_db
+from helpers.push_helpers.inventory_processor import NaturalLanguageInventoryProcessor
+from helpers.push_helpers.taste_profile_processor import TasteProfileProcessor
+from helpers.push_helpers.saved_meals_processor import SavedMealsProcessor
+from helpers.push_helpers.shopping_list_processor import ShoppingListProcessor
+from helpers.push_helpers.daily_notes_processor import DailyNotesProcessor
+import traceback
+
+
+@mcp.tool
+@with_db
+def update_inventory(db, tables, user_input: str) -> str:
+    """Update the kitchen inventory.
+
+    Args:
+        user_input: Natural language description of inventory changes such as
+            items added, removed or used.
+
+    Returns:
+        Confirmation text summarizing the updates that were applied.
+    """
+    print(f"[Tool Called] update_inventory with input: '{user_input}'")
+    try:
+        processor = NaturalLanguageInventoryProcessor(tables['inventory'], db)
+        _, confirmation = processor.process_inventory_changes(user_input)
+        return confirmation
+    except Exception as e:
+        print(f"[ERROR] Tool 'update_inventory' failed: {e}")
+        print(traceback.format_exc())
+        return f"An error occurred while processing inventory changes: {str(e)}"
+
+
+@mcp.tool
+@with_db
+def update_taste_profile(db, tables, user_request: str) -> str:
+    """Adjust the saved taste profile.
+
+    Args:
+        user_request: Natural language instructions describing likes,
+            dislikes or dietary changes.
+
+    Returns:
+        A confirmation message summarizing the profile updates.
+    """
+    print(f"[Tool Called] update_taste_profile with input: '{user_request}'")
+    try:
+        processor = TasteProfileProcessor(tables['taste_profile'])
+        _, confirmation = processor.update_taste_profile(user_request)
+        return confirmation
+    except Exception as e:
+        print(f"[ERROR] Tool 'update_taste_profile' failed: {e}")
+        print(traceback.format_exc())
+        return f"An error occurred while updating the taste profile: {str(e)}"
+
+
+@mcp.tool
+@with_db
+def update_saved_meals(db, tables, user_input: str) -> str:
+    """Manage saved meals.
+
+    Args:
+        user_input: Natural language request describing which recipes to add,
+            update or remove.
+
+    Returns:
+        Confirmation text detailing the changes made to the saved meals list.
+    """
+    print(f"[Tool Called] update_saved_meals with input: '{user_input}'")
+    try:
+        processor = SavedMealsProcessor(tables['saved_meals'], db)
+        _, confirmation = processor.process_saved_meals_changes(user_input)
+        return confirmation
+    except Exception as e:
+        print(f"[ERROR] Tool 'update_saved_meals' failed: {e}")
+        print(traceback.format_exc())
+        return f"An error occurred while processing saved meals changes: {str(e)}"
+
+
+@mcp.tool
+@with_db
+def update_shopping_list(db, tables, user_input: str) -> str:
+    """Modify the shopping list.
+
+    Args:
+        user_input: Text describing items to add, remove or clear from the list.
+
+    Returns:
+        Confirmation describing the final state of the shopping list.
+    """
+    print(f"[Tool Called] update_shopping_list with input: '{user_input}'")
+    try:
+        processor = ShoppingListProcessor(tables['shopping_list'], tables['ingredients_foods'], db)
+        _, confirmation = processor.process_shopping_list_changes(user_input)
+        return confirmation
+    except Exception as e:
+        print(f"[ERROR] Tool 'update_shopping_list' failed: {e}")
+        print(traceback.format_exc())
+        return f"An error occurred while processing shopping list changes: {str(e)}"
+
+
+@mcp.tool
+@with_db
+def update_daily_plan(db, tables, user_input: str) -> str:
+    """Modify entries in the daily meal plan.
+
+    Args:
+        user_input: Natural language request mentioning meals or notes to add,
+            change or remove for particular days.
+
+    Returns:
+        Confirmation describing what updates were made to the plan.
+    """
+    print(f"[Tool Called] update_daily_plan with input: '{user_input}'")
+    try:
+        processor = DailyNotesProcessor(tables['daily_planner'], tables['saved_meals'], db)
+        _, confirmation = processor.process_daily_notes_changes(user_input)
+        return confirmation
+    except Exception as e:
+        print(f"[ERROR] Tool 'update_daily_plan' failed: {e}")
+        print(traceback.format_exc())
+        return f"An error occurred while processing daily plan changes: {str(e)}"

--- a/test_mcp_client.py
+++ b/test_mcp_client.py
@@ -1,0 +1,34 @@
+"""Simple client test for the MCP server."""
+
+import asyncio
+import subprocess
+import sys
+import time
+
+from fastmcp import Client
+
+SERVER_SCRIPT = "mcp_server.py"
+# FastMCP defaults to serving under /mcp when using HTTP transport
+SERVER_URL = "http://localhost:8000/mcp"
+
+async def call_inventory():
+    async with Client(SERVER_URL) as client:
+        tools = await client.list_tools()
+        print("Tools on server:", [t.name for t in tools])
+        result = await client.call_tool("get_inventory_context")
+        text = result[0].text if result else "(no content)"
+        print("Inventory context:\n", text)
+
+
+def main():
+    server = subprocess.Popen([sys.executable, SERVER_SCRIPT])
+    try:
+        time.sleep(2)  # wait for server to start
+        asyncio.run(call_inventory())
+    finally:
+        server.terminate()
+        server.wait()
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- implement `with_db` decorator to handle DB init and cleanup
- convert tool modules to use `with_db`
- add `mcp_server.py` launcher and client test script

## Testing
- `pytest -q`
- `python test_mcp_client.py`

------
https://chatgpt.com/codex/tasks/task_e_685e2865e4908320a2ccf892b3d0d1bb