### PR TITLE
Refactor daily planner range handling

### DIFF
--- a/debug/reset_db.py
+++ b/debug/reset_db.py
@@ -744,19 +744,13 @@ Dislikes:
                 print(f"[FAIL] Failed to add meal idea: {name}")
     
     def load_daily_planner(self):
-        """Loads sample data into the daily_planner table for 2025."""
+        """Initializes the daily_planner table without pre-populating days."""
         print("\nLoading daily planner...")
-        
-        # Insert entries for each day of 2025
-        start_date = datetime(2025, 1, 1).date()
-        end_date = datetime(2025, 12, 31).date()
-        current_date = start_date
-        
-        while current_date <= end_date:
-            success = self.tables["daily_planner"].create(current_date, None, [])
-            current_date += timedelta(days=1)
-        
-        print("[OK] Daily planner populated for 2025")
+
+        # Simply ensure the table exists. Days will be created on demand.
+        self.tables["daily_planner"].create_table()
+
+        print("[OK] Daily planner initialized (no pre-created days)")
     
     def load_shopping_list(self):
         """Loads sample items into the shopping_list table."""

--- a/helpers/pull_helper.py
+++ b/helpers/pull_helper.py
@@ -195,9 +195,6 @@ class PullHelper:
                     start_dt = end_dt - timedelta(days=7)
                 elif start_dt is not None and end_dt is None:
                     end_dt = start_dt + timedelta(days=7)
-                elif start_dt is None and end_dt is None:
-                    start_dt = today
-                    end_dt = start_dt + timedelta(days=7)
 
             tomorrow = today + timedelta(days=1)
 

--- a/helpers/pull_helper.py
+++ b/helpers/pull_helper.py
@@ -156,21 +156,55 @@ class PullHelper:
             print(f"[ERROR] PullHelper failed to get shopping list context: {e}\n{traceback.format_exc()}")
             return "Error retrieving shopping list."
 
-    def get_daily_notes_context(self) -> str:
-        """Fetches the user's meal plan for the upcoming week."""
+    def get_daily_notes_context(
+        self,
+        start_date: Optional[date] = None,
+        end_date: Optional[date] = None,
+    ) -> str:
+        """Fetch the user's meal plan for the given range.
+
+        Args:
+            start_date: Beginning of the desired range. Defaults to today.
+            end_date: End of the range (inclusive). Defaults to one week from
+                ``start_date``.
+
+        Returns:
+            A formatted string describing plans in the requested window or a
+            message if none exist.
+        """
         try:
             daily_planner_table = self.tables.get('daily_planner')
             saved_meals_table = self.tables.get('saved_meals')
-            if not daily_planner_table or not saved_meals_table: 
+            if not daily_planner_table or not saved_meals_table:
                 return "Error: DailyPlanner or SavedMeals table not available."
 
+            # Determine range defaults
             today = date.today()
+
+            if start_date is None and end_date is None:
+                start_dt = today
+                end_dt = start_dt + timedelta(days=7)
+            else:
+                start_dt = start_date
+                end_dt = end_date
+                if isinstance(start_dt, str):
+                    start_dt = datetime.strptime(start_dt, "%Y-%m-%d").date()
+                if isinstance(end_dt, str):
+                    end_dt = datetime.strptime(end_dt, "%Y-%m-%d").date()
+                if start_dt is None and end_dt is not None:
+                    start_dt = end_dt - timedelta(days=7)
+                elif start_dt is not None and end_dt is None:
+                    end_dt = start_dt + timedelta(days=7)
+                elif start_dt is None and end_dt is None:
+                    start_dt = today
+                    end_dt = start_dt + timedelta(days=7)
+
             tomorrow = today + timedelta(days=1)
-            end_date = today + timedelta(days=7)
-            
-            all_entries = daily_planner_table.read()
+
+            # Fetch entries within requested range
+            all_entries = daily_planner_table.read(start_date=start_dt, end_date=end_dt)
             if not all_entries:
-                return "No meal plans found for the upcoming week."
+                return "No meal plans found for the specified range."
                 
             context = ""
             found_entries = False
@@ -187,7 +221,7 @@ class PullHelper:
                 except (ValueError, TypeError):
                     continue
 
-                if today <= entry_date <= end_date:
+                if start_dt <= entry_date <= end_dt:
                     found_entries = True
                     try: notes = entry['notes']
                     except KeyError: notes = None
@@ -217,7 +251,11 @@ class PullHelper:
                     formatted_date = entry_date.strftime("%A, %B %d")
                     context += f"{relative_prefix}({formatted_date}): {meal_text} (Notes: {notes})\n"
             
-            return context.strip() if found_entries else "No meal plans found for the upcoming week."
+            return (
+                context.strip()
+                if found_entries
+                else "No meal plans found for the specified range."
+            )
         except Exception as e:
             print(f"[ERROR] PullHelper failed to get daily notes context: {e}\n{traceback.format_exc()}")
             return "Error retrieving daily meal plans."

--- a/helpers/push_helpers/daily_notes_processor.py
+++ b/helpers/push_helpers/daily_notes_processor.py
@@ -112,9 +112,10 @@ User input: {user_input}
             date_info = self.get_current_date_info()
             today = date_info["today_date_obj"]
             end_date = today + timedelta(days=7)
-            
+
             plans_text = "No current plans found."
-            all_entries = daily_planner.read()
+            # Only fetch entries within the upcoming week
+            all_entries = daily_planner.read(start_date=today, end_date=end_date)
             
             if all_entries:
                 formatted_entries = []


### PR DESCRIPTION
## Summary
- change daily planner queries to accept a date range
- remove pre-population of the planner
- limit weekly planner pulls to a specific range
- update processor to only read upcoming entries
- allow PullHelper to specify a start and end date

## Testing
- `python -m py_compile db/db_functions.py helpers/pull_helper.py helpers/push_helpers/daily_notes_processor.py debug/reset_db.py`
- `pytest -q` *(no tests discovered)*
- `python test_mcp_tools_full.py` *(fails: Client failed to connect)*

------
https://chatgpt.com/codex/tasks/task_e_68894de1b1a48320b0a6926c61c465b6