### PR TITLE
Refactor CoachByte tools into separate module

### DIFF
--- a/coachbyte/agent.py
+++ b/coachbyte/agent.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 
 from agents import Agent, Runner
 
-import tools
+import agent_tools as tools
 from db import get_connection
 import psycopg2.extras
 

--- a/coachbyte/agent_tools.py
+++ b/coachbyte/agent_tools.py
@@ -1,0 +1,20 @@
+"""OpenAI Agent FunctionTool wrappers for CoachByte tools."""
+
+from agents import function_tool
+import coachbyte.tools as base
+
+# Wrap each plain function
+new_daily_plan = function_tool(strict_mode=False)(base.new_daily_plan)
+get_today_plan = function_tool(strict_mode=False)(base.get_today_plan)
+log_completed_set = function_tool(strict_mode=False)(base.log_completed_set)
+complete_planned_set = function_tool(strict_mode=False)(base.complete_planned_set)
+update_summary = function_tool(strict_mode=False)(base.update_summary)
+get_recent_history = function_tool(strict_mode=False)(base.get_recent_history)
+set_weekly_split_day = function_tool(strict_mode=False)(base.set_weekly_split_day)
+get_weekly_split = function_tool(strict_mode=False)(base.get_weekly_split)
+run_sql = function_tool(strict_mode=False)(base.run_sql)
+arbitrary_update = function_tool(strict_mode=False)(base.arbitrary_update)
+set_timer = function_tool(strict_mode=False)(base.set_timer)
+get_timer = function_tool(strict_mode=False)(base.get_timer)
+
+__all__ = base.__all__

--- a/coachbyte/mcp_server.py
+++ b/coachbyte/mcp_server.py
@@ -1,0 +1,33 @@
+"""Run the CoachByte MCP server exposing all workout tools."""
+
+from fastmcp import FastMCP
+import tools
+
+mcp = FastMCP("CoachByte Tools")
+
+for name in tools.__all__:
+    mcp.tool(getattr(tools, name))
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Run the aggregated CoachByte MCP server",
+    )
+    parser.add_argument(
+        "--host",
+        default="0.0.0.0",
+        help="Host (default 0.0.0.0)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8100,
+        help="Port (default 8100)",
+    )
+    args = parser.parse_args()
+
+    url = f"http://{args.host if args.host != '0.0.0.0' else 'localhost'}:{args.port}/sse"
+    print(f"[CoachByte] Running via SSE at {url}")
+
+    mcp.run(transport="sse", host=args.host, port=args.port)

--- a/coachbyte/tools/__init__.py
+++ b/coachbyte/tools/__init__.py
@@ -5,7 +5,7 @@ from datetime import date, timedelta, datetime, timezone
 import psycopg2.extras
 
 from db import get_connection, get_today_log_id
-from agents import function_tool
+
 
 def get_corrected_time():
     """Get the current UTC time"""
@@ -36,7 +36,6 @@ def _get_exercise_id(conn, name: str) -> int:
     return cur.fetchone()['id']
 
 
-@function_tool(strict_mode=False)
 def new_daily_plan(items: List[Dict[str, Any]]):
     """Create today's daily workout plan with a list of planned sets.
     
@@ -83,7 +82,6 @@ def new_daily_plan(items: List[Dict[str, Any]]):
     return f"planned {len(items)} sets for today"
 
 
-@function_tool(strict_mode=False)
 def get_today_plan() -> List[Dict[str, Any]]:
     """Retrieve today's planned workout sets in order.
     
@@ -116,7 +114,6 @@ def get_today_plan() -> List[Dict[str, Any]]:
     return rows
 
 
-@function_tool(strict_mode=False)
 def log_completed_set(exercise: str, reps: int, load: float):
     """Record a completed set that was NOT part of the planned workout (for extra/unplanned sets).
     
@@ -153,7 +150,6 @@ def log_completed_set(exercise: str, reps: int, load: float):
     return "logged"
 
 
-@function_tool(strict_mode=False)
 def complete_planned_set(exercise: Optional[str] = None, reps: Optional[int] = None, load: Optional[float] = None):
     """Complete the next planned set in the workout queue, with optional overrides.
     
@@ -270,7 +266,6 @@ def complete_planned_set(exercise: Optional[str] = None, reps: Optional[int] = N
         conn.close()
 
 
-@function_tool(strict_mode=False)
 def update_summary(text: str):
     """Update today's workout summary with a descriptive text.
     
@@ -299,7 +294,6 @@ def update_summary(text: str):
     return "summary updated"
 
 
-@function_tool(strict_mode=False)
 def get_recent_history(days: int) -> List[Dict[str, Any]]:
     """Retrieve workout history for the specified number of recent days.
     
@@ -345,7 +339,6 @@ def get_recent_history(days: int) -> List[Dict[str, Any]]:
     return rows
 
 
-@function_tool(strict_mode=False)
 def set_weekly_split_day(day: str, items: List[Dict[str, Any]]):
     """Replace the weekly split plan for the specified day.
 
@@ -401,7 +394,6 @@ def set_weekly_split_day(day: str, items: List[Dict[str, Any]]):
     return f"split updated for {key} with {len(items)} sets"
 
 
-@function_tool(strict_mode=False)
 def get_weekly_split(day: Optional[str] = None) -> List[Dict[str, Any]]:
     """Retrieve the weekly split plan.
 
@@ -459,7 +451,6 @@ def _execute_sql(query: str, params: Optional[Dict[str, Any]] = None, confirm: b
     return rows
 
 
-@function_tool(strict_mode=False)
 def run_sql(query: str, params: Optional[Dict[str, Any]] = None, confirm: bool = False):
     """Execute SQL queries against the workout database.
     
@@ -485,7 +476,6 @@ def run_sql(query: str, params: Optional[Dict[str, Any]] = None, confirm: bool =
     return _execute_sql(query, params, confirm)
 
 
-@function_tool(strict_mode=False)
 def arbitrary_update(query: str, params: Optional[Dict[str, Any]] = None):
     """Execute UPDATE, INSERT, or DELETE SQL statements with automatic confirmation.
     
@@ -514,7 +504,6 @@ def arbitrary_update(query: str, params: Optional[Dict[str, Any]] = None):
     return _execute_sql(query, params=params, confirm=True)
 
 
-@function_tool(strict_mode=False)
 def set_timer(minutes: int):
     """Set a workout timer for rest periods or workout duration.
     
@@ -558,7 +547,6 @@ def set_timer(minutes: int):
         return f"Timer error: {e}"
 
 
-@function_tool(strict_mode=False)
 def get_timer() -> Dict[str, Any]:
     """Check the current timer status and remaining time.
     


### PR DESCRIPTION
## Summary
- move all CoachByte tool implementations into `coachbyte/tools/`
- provide `agent_tools` module that wraps plain functions with `FunctionTool`
- simplify MCP server to load plain functions directly
- update agent to import wrappers

## Testing
- `pytest -q`
- `python coachbyte/mcp_server.py --help`
- `python coachbyte/mcp_server.py --port 8101` (server started then interrupted)

------
https://chatgpt.com/codex/tasks/task_e_688b18a90ba48320966d0256f1ef5285