### PR TITLE
Combine GeneralByte tools into single module

### DIFF
--- a/generalbyte/__init__.py
+++ b/generalbyte/__init__.py
@@ -1,0 +1,5 @@
+"""GeneralByte package providing MCP tools."""
+
+from .tool import mcp
+
+__all__ = ["mcp"]

--- a/generalbyte/mcp_server.py
+++ b/generalbyte/mcp_server.py
@@ -1,0 +1,29 @@
+"""Run the GeneralByte MCP server with Home Assistant tools."""
+
+from fastmcp import FastMCP
+
+if __package__:
+    from . import tool
+else:  # pragma: no cover - direct script execution
+    import os
+    import sys
+
+    sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+    import generalbyte.tool as tool
+
+mcp = FastMCP("GeneralByte Aggregated Tools")
+
+mcp.mount(tool.mcp, prefix="general")
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run the GeneralByte MCP server")
+    parser.add_argument("--host", default="0.0.0.0", help="Host (default 0.0.0.0)")
+    parser.add_argument("--port", type=int, default=8050, help="Port (default 8050)")
+    args = parser.parse_args()
+
+    url = f"http://{args.host if args.host != '0.0.0.0' else 'localhost'}:{args.port}/sse"
+    print(f"[GeneralByte] Running via SSE at {url}")
+
+    mcp.run(transport="sse", host=args.host, port=args.port)

--- a/generalbyte/tool.py
+++ b/generalbyte/tool.py
@@ -1,0 +1,108 @@
+"""Tools for notifications and to-do lists via Home Assistant."""
+
+import os
+from typing import Optional
+
+import requests
+from fastmcp import FastMCP
+
+mcp = FastMCP("GeneralByte Tools")
+
+HA_URL = os.getenv("HA_URL", "http://localhost:8123")
+HA_TOKEN = os.getenv("HA_TOKEN")
+DEFAULT_NOTIFY_SERVICE = os.getenv("HA_NOTIFY_SERVICE", "mobile_app_my_phone")
+
+HEADERS = {
+    "Authorization": f"Bearer {HA_TOKEN}",
+    "Content-Type": "application/json",
+}
+
+
+def call_service(domain: str, service: str, data: dict) -> dict:
+    """Call a Home Assistant service and return the JSON response."""
+    url = f"{HA_URL}/api/services/{domain}/{service}"
+    response = requests.post(url, headers=HEADERS, json=data, timeout=10)
+    response.raise_for_status()
+    try:
+        return response.json()
+    except ValueError:
+        return {}
+
+
+@mcp.tool
+def send_phone_notification(message: str, service: str | None = None) -> str:
+    """Send a notification message to the configured phone via Home Assistant."""
+    if not HA_TOKEN:
+        return "Home Assistant token not configured"
+    target_service = service or DEFAULT_NOTIFY_SERVICE
+    call_service("notify", target_service, {"message": message})
+    return "Notification sent"
+
+
+@mcp.tool
+def get_todo_list(entity_id: str, status: Optional[str] = None) -> dict:
+    """Return items from a Home Assistant to-do list."""
+    if not HA_TOKEN:
+        return {"error": "Home Assistant token not configured"}
+    payload = {"entity_id": entity_id}
+    if status:
+        payload["status"] = [status]
+    return call_service("todo", "get_items", payload)
+
+
+@mcp.tool
+def modify_todo_item(
+    action: str,
+    entity_id: str,
+    item: Optional[str] = None,
+    uid: Optional[str] = None,
+    rename: Optional[str] = None,
+    status: Optional[str] = None,
+    description: Optional[str] = None,
+    due_date: Optional[str] = None,
+    due_datetime: Optional[str] = None,
+) -> str:
+    """Create, update or delete a to-do list item."""
+    if not HA_TOKEN:
+        return "Home Assistant token not configured"
+
+    data = {"entity_id": entity_id}
+
+    if action == "create":
+        if not item:
+            return "Item summary required for creation"
+        data.update({"item": item})
+        if description:
+            data["description"] = description
+        if due_date:
+            data["due_date"] = due_date
+        if due_datetime:
+            data["due_datetime"] = due_datetime
+        service = "add_item"
+    elif action == "update":
+        identifier = uid or item
+        if not identifier:
+            return "Item name or uid required for update"
+        data.update({"item": identifier})
+        if rename:
+            data["rename"] = rename
+        if status:
+            data["status"] = status
+        if description:
+            data["description"] = description
+        if due_date:
+            data["due_date"] = due_date
+        if due_datetime:
+            data["due_datetime"] = due_datetime
+        service = "update_item"
+    elif action == "delete":
+        identifier = uid or item
+        if not identifier:
+            return "Item name or uid required for deletion"
+        data.update({"item": identifier})
+        service = "remove_item"
+    else:
+        return "Invalid action. Use 'create', 'update', or 'delete'."
+
+    call_service("todo", service, data)
+    return f"Todo item {action} request sent"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ psycopg2-binary
 pydantic>=2.0.0
 streamlit
 requests
+fastmcp


### PR DESCRIPTION
## Summary
- consolidate notification and to-do tools into `generalbyte/tool.py`
- expose unified tools via `generalbyte.__init__`
- update MCP server to mount the single toolset
- remove old modules
- fix direct execution of MCP server

## Testing
- `pytest -q chefbyte/test_mcp_client.py`


------
https://chatgpt.com/codex/tasks/task_e_688b285a88548320aab4a42bd5bc9cc6