### PR TITLE
Add basic agent tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pig4.py
 # Node
 node_modules/
 dist/
+data/

--- a/TESTS.md
+++ b/TESTS.md
@@ -1,0 +1,35 @@
+# MCP Server Test Suite
+
+This project includes simple agents that exercise each sub-agent's MCP server.
+Tests use the OpenAI `agents` SDK with the `gpt-4o` model.  Every test script
+starts the appropriate server, issues natural language prompts and prints a JSON
+report.
+
+## ChefByte
+* `chefbyte/test_agent.py`
+  - Resets the SQLite database to the provided sample data.
+  - Starts `chefbyte_mcp_server.py` and connects an Agent via SSE.
+  - For each major table (inventory, taste profile, saved meals, shopping list
+    and daily planner) it:
+    1. Captures the current rows.
+    2. Prompts the agent to update the table (e.g. "add carrots to inventory").
+    3. Captures the rows again and asks the agent to display them.
+    4. Stores the before/after data along with the agent responses.
+  - A short LLM evaluation summarises whether the updates worked.
+
+## CoachByte
+* `coachbyte/test_agent.py`
+  - Attempts to initialize the PostgreSQL database with sample data. If the
+    connection fails the test is skipped.
+  - If successful, starts `coachbyte_mcp_server.py` and runs a couple of simple
+    prompts to fetch and create workout plans.
+
+## GeneralByte
+* `generalbyte/test_agent.py`
+  - Starts `generalbyte_mcp_server.py` and runs prompts for the notification and
+    to-do list tools.
+
+## Running All Tests
+Execute `python run_all_tests.py` from the project root. Each test script prints
+its own JSON output. The aggregator collects return codes and captured output for
+review.

--- a/chefbyte/test_agent.py
+++ b/chefbyte/test_agent.py
@@ -1,0 +1,122 @@
+import asyncio
+import subprocess
+import sys
+import time
+import json
+
+from agents import Agent
+from agents.mcp.server import MCPServerSse, MCPServerSseParams
+from agents.run import Runner
+
+from debug.reset_db import reset_database
+from db.db_functions import Database, Inventory, TasteProfile, SavedMeals, ShoppingList, DailyPlanner
+
+SERVER_PORT = 8000
+SERVER_URL = f"http://localhost:{SERVER_PORT}/sse"
+SERVER_SCRIPT = "chefbyte/chefbyte_mcp_server.py"
+MODEL = "gpt-4o"
+
+# ---------------------------------------------------------------------
+# Helper functions for DB snapshots
+
+def get_inventory_rows():
+    db = Database()
+    db.connect(verbose=False)
+    rows = Inventory(db).read()
+    db.disconnect(verbose=False)
+    return rows
+
+def get_taste_profile():
+    db = Database()
+    db.connect(verbose=False)
+    profile = TasteProfile(db).read()
+    db.disconnect(verbose=False)
+    return profile
+
+def get_saved_meals():
+    db = Database()
+    db.connect(verbose=False)
+    rows = SavedMeals(db).read()
+    db.disconnect(verbose=False)
+    return rows
+
+def get_shopping_list():
+    db = Database()
+    db.connect(verbose=False)
+    rows = ShoppingList(db).read()
+    db.disconnect(verbose=False)
+    return rows
+
+def get_daily_plan():
+    db = Database()
+    db.connect(verbose=False)
+    rows = DailyPlanner(db).read()
+    db.disconnect(verbose=False)
+    return rows
+
+# ---------------------------------------------------------------------
+async def run_agent(prompt: str) -> str:
+    server = MCPServerSse(MCPServerSseParams(url=SERVER_URL))
+    await server.connect()
+    agent = Agent(
+        name="ChefByteTest",
+        instructions="You are testing the ChefByte tools. Use them to satisfy the user request.",
+        mcp_servers=[server],
+        model=MODEL,
+    )
+    result = await Runner.run(agent, prompt)
+    await server.cleanup()
+    return result.final_output
+
+async def test_table(before_fn, prompt_update, prompt_view):
+    before = before_fn()
+    update_out = await run_agent(prompt_update)
+    after = before_fn()
+    view_out = await run_agent(prompt_view)
+    return {
+        "before": before,
+        "update_output": update_out,
+        "after": after,
+        "query_output": view_out,
+    }
+
+async def run_tests():
+    results = {}
+    results["inventory"] = await test_table(get_inventory_rows, "add carrots to inventory", "show inventory")
+    results["taste_profile"] = await test_table(get_taste_profile, "i like spicy food", "what is my taste profile")
+    results["saved_meals"] = await test_table(get_saved_meals, "save meal grilled cheese", "list saved meals")
+    results["shopping_list"] = await test_table(get_shopping_list, "add milk to my shopping list", "show shopping list")
+    results["daily_planner"] = await test_table(get_daily_plan, "schedule pasta for tomorrow", "show my daily plan")
+    return results
+
+# ---------------------------------------------------------------------
+def llm_judge(results: dict) -> str:
+    try:
+        import openai
+        client = openai.OpenAI()
+        chat = [
+            {"role": "system", "content": "You evaluate whether each table update succeeded based on before/after data."},
+            {"role": "user", "content": json.dumps(results, default=str)},
+        ]
+        resp = client.chat.completions.create(model=MODEL, messages=chat)
+        return resp.choices[0].message.content
+    except Exception as e:
+        return f"LLM judge failed: {e}"
+
+# ---------------------------------------------------------------------
+def main():
+    print("Resetting ChefByte database...")
+    reset_database()
+    server = subprocess.Popen([sys.executable, SERVER_SCRIPT, "--port", str(SERVER_PORT)])
+    try:
+        time.sleep(2)
+        results = asyncio.run(run_tests())
+    finally:
+        server.terminate()
+        server.wait()
+    print(json.dumps(results, indent=2, default=str))
+    judgment = llm_judge(results)
+    print("\nLLM Evaluation:\n", judgment)
+
+if __name__ == "__main__":
+    main()

--- a/coachbyte/test_agent.py
+++ b/coachbyte/test_agent.py
@@ -1,0 +1,61 @@
+import asyncio
+import subprocess
+import sys
+import time
+import json
+
+from agents import Agent
+from agents.mcp.server import MCPServerSse, MCPServerSseParams
+from agents.run import Runner
+
+import db
+
+SERVER_PORT = 8100
+SERVER_URL = f"http://localhost:{SERVER_PORT}/sse"
+SERVER_SCRIPT = "coachbyte/coachbyte_mcp_server.py"
+MODEL = "gpt-4o"
+
+async def run_agent(prompt: str) -> str:
+    server = MCPServerSse(MCPServerSseParams(url=SERVER_URL))
+    await server.connect()
+    agent = Agent(
+        name="CoachByteTest",
+        instructions="Use the workout tools to respond to the user.",
+        mcp_servers=[server],
+        model=MODEL,
+    )
+    try:
+        result = await Runner.run(agent, prompt)
+        return result.final_output
+    finally:
+        await server.cleanup()
+
+def try_reset_db():
+    try:
+        db.init_db(sample=True)
+        return True
+    except Exception as e:
+        print("CoachByte DB not accessible:", e)
+        return False
+
+async def run_tests():
+    results = {}
+    results["plan"] = await run_agent("show today's plan")
+    results["new_plan"] = await run_agent("create simple plan with push ups")
+    return results
+
+def main():
+    if not try_reset_db():
+        print("Skipping CoachByte tests")
+        return
+    server = subprocess.Popen([sys.executable, SERVER_SCRIPT, "--port", str(SERVER_PORT)])
+    try:
+        time.sleep(2)
+        results = asyncio.run(run_tests())
+    finally:
+        server.terminate()
+        server.wait()
+    print(json.dumps(results, indent=2))
+
+if __name__ == "__main__":
+    main()

--- a/generalbyte/test_agent.py
+++ b/generalbyte/test_agent.py
@@ -1,0 +1,44 @@
+import asyncio
+import subprocess
+import sys
+import time
+import json
+
+from agents import Agent
+from agents.mcp.server import MCPServerSse, MCPServerSseParams
+from agents.run import Runner
+
+SERVER_PORT = 8050
+SERVER_URL = f"http://localhost:{SERVER_PORT}/sse"
+SERVER_SCRIPT = "generalbyte/generalbyte_mcp_server.py"
+MODEL = "gpt-4o"
+
+async def run_agent(prompt: str) -> str:
+    server = MCPServerSse(MCPServerSseParams(url=SERVER_URL))
+    await server.connect()
+    agent = Agent(name="GeneralByteTest", instructions="Use the general tools.", mcp_servers=[server], model=MODEL)
+    try:
+        result = await Runner.run(agent, prompt)
+        return result.final_output
+    finally:
+        await server.cleanup()
+
+async def run_tests():
+    results = {}
+    results["notify"] = await run_agent("send a notification")
+    results["todo_list"] = await run_agent("show my todo list")
+    results["modify_todo"] = await run_agent("create todo item buy milk")
+    return results
+
+def main():
+    server = subprocess.Popen([sys.executable, SERVER_SCRIPT, "--port", str(SERVER_PORT)])
+    try:
+        time.sleep(2)
+        results = asyncio.run(run_tests())
+    finally:
+        server.terminate()
+        server.wait()
+    print(json.dumps(results, indent=2))
+
+if __name__ == "__main__":
+    main()

--- a/run_all_tests.py
+++ b/run_all_tests.py
@@ -1,0 +1,27 @@
+import subprocess
+import sys
+import json
+
+TEST_SCRIPTS = [
+    "chefbyte/test_agent.py",
+    "coachbyte/test_agent.py",
+    "generalbyte/test_agent.py",
+]
+
+
+def run_script(path):
+    proc = subprocess.run([sys.executable, path], capture_output=True, text=True)
+    return {
+        "script": path,
+        "returncode": proc.returncode,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+    }
+
+
+def main():
+    results = [run_script(s) for s in TEST_SCRIPTS]
+    print(json.dumps(results, indent=2))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add ChefByte test agent using OpenAI agents
- add similar test harnesses for CoachByte and GeneralByte
- provide a master `run_all_tests.py` runner
- document the tests in `TESTS.md`
- ignore generated databases

## Testing
- `python run_all_tests.py` *(fails: Error initializing MCP server)*

------
https://chatgpt.com/codex/tasks/task_e_688be93f3c3c8320b3de158373e1a38f